### PR TITLE
Disable autocomplete for secret values field

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 services:
   ui:
     build:

--- a/src/app/routes/_index.tsx
+++ b/src/app/routes/_index.tsx
@@ -155,7 +155,13 @@ export default function Index() {
                 )}
 
                 <label htmlFor="value">Value</label>
-                <input type="text" id="value" name="value" required />
+                <input
+                    type="text"
+                    id="value"
+                    name="value"
+                    autocomplete="off"
+                    required
+                />
 
                 <input type="submit" value="Encrypt" />
             </Form>


### PR DESCRIPTION
Disable autocomplete for the "Value" field to prevent credentials leakage.

Also, remove the `version` field in the `docker-compose.yaml` file, as it [has been obsoleted](https://github.com/docker/compose/issues/11628) and generates warnings.